### PR TITLE
Fix mobile menu toggle on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,10 @@
 
     /* На мобильном стартуем со скрытым меню */
     @media (max-width: 768px) {
+      /* sidebar hidden by default on narrow screens */
       #app { grid-template-columns: 0 1fr; }
+      /* allow sidebar to appear when not collapsed */
+      #app:not(.collapsed) { grid-template-columns: 320px 1fr; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- allow sidebar to expand on mobile by overriding default collapsed grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b62900608327867573011c296725