### PR TITLE
Fix mobile menu toggle on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 
     /* Ярлык для открытия меню, когда оно скрыто */
     #toggleTab {
-      position:fixed; left:8px; top:12px; z-index:1100;
+      position:fixed; left:8px; top:calc(var(--top-slider-space) + 12px); z-index:1100;
       padding:8px 10px; background:#222; color:var(--fg);
       border:1px solid var(--border); border-radius:999px; cursor:pointer;
       display:none; align-items:center; gap:6px; user-select:none;
@@ -62,7 +62,10 @@
 
     /* На мобильном стартуем со скрытым меню */
     @media (max-width: 768px) {
+      /* sidebar hidden by default on narrow screens */
       #app { grid-template-columns: 0 1fr; }
+      /* allow sidebar to appear when not collapsed */
+      #app:not(.collapsed) { grid-template-columns: 320px 1fr; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- allow sidebar to expand on mobile by overriding default collapsed grid
- offset hidden-menu toggle button below timeline slider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b62900608327867573011c296725